### PR TITLE
solo5-bindings: Sync with ocaml-freestanding changes

### DIFF
--- a/solo5-bindings/Makefile
+++ b/solo5-bindings/Makefile
@@ -1,6 +1,8 @@
 OPAM_DIR=$(shell opam config var prefix)
 
-CFLAGS=$(shell PKG_CONFIG_PATH=$(OPAM_DIR)/lib/pkgconfig pkg-config ocaml-freestanding --cflags)
+FREESTANDING_CFLAGS=$(shell PKG_CONFIG_PATH=$(OPAM_DIR)/lib/pkgconfig pkg-config ocaml-freestanding --cflags)
+CC=gcc
+CFLAGS=-O2 -g -Wall -Werror $(FREESTANDING_CFLAGS)
 
 OBJS=\
 alloc_pages_stubs.o \

--- a/solo5-bindings/alloc_pages_stubs.c
+++ b/solo5-bindings/alloc_pages_stubs.c
@@ -15,6 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #define PAGE_SIZE 4096

--- a/solo5-bindings/clock_stubs.c
+++ b/solo5-bindings/clock_stubs.c
@@ -16,6 +16,8 @@
 
 #include "solo5.h"
 
+#include <sys/time.h>
+
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>

--- a/solo5-bindings/cstruct_stubs.c
+++ b/solo5-bindings/cstruct_stubs.c
@@ -15,15 +15,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#if 0
-#include <sys/param.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <string.h>
-#include <stdint.h>
-#endif
-
 #include "solo5.h"
+
+#include <string.h>
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>

--- a/solo5-bindings/main.c
+++ b/solo5-bindings/main.c
@@ -15,6 +15,9 @@
  */
 
 #include "solo5.h"
+
+#include <stdio.h>
+
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/callback.h>

--- a/solo5-bindings/mm_stubs.c
+++ b/solo5-bindings/mm_stubs.c
@@ -15,6 +15,9 @@
  */
 
 #include "solo5.h"
+
+#include <stdio.h>
+
 #include <caml/mlvalues.h>
 
 CAMLprim value

--- a/solo5-bindings/solo5_block_stubs.c
+++ b/solo5-bindings/solo5_block_stubs.c
@@ -18,6 +18,9 @@
 
 #include "solo5.h"
 
+#include <assert.h>
+#include <stdio.h>
+
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>

--- a/solo5-bindings/solo5_console_stubs.c
+++ b/solo5-bindings/solo5_console_stubs.c
@@ -18,6 +18,8 @@
 
 #include "solo5.h"
 
+#include <string.h>
+
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>
@@ -30,7 +32,7 @@ CAMLprim value stub_console_write(value arg) {
     CAMLparam1(arg);
 
     const char *str = String_val(arg);
-    printf("%s", str);
+    solo5_console_write(str, strlen(str));
 
     CAMLreturn(Val_unit);
 }

--- a/solo5-bindings/solo5_net_stubs.c
+++ b/solo5-bindings/solo5_net_stubs.c
@@ -18,6 +18,8 @@
 
 #include "solo5.h"
 
+#include <assert.h>
+
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/signals.h>


### PR DESCRIPTION
Ocaml-freestanding now has strict namespacing of libc headers to support
OCaml 4.03.0. Correctly include libc headers in Solo5 bindings. Also
update the Makefile to use stricter CFLAGS to catch errors.