### PR TITLE
FreeBSD support

### DIFF
--- a/mirage-solo5.opam
+++ b/mirage-solo5.opam
@@ -21,4 +21,4 @@ depends: [
   "mirage-profile" {>= "0.3"}
   "ocaml-freestanding"
 ]
-available: [ ocaml-version >= "4.01.0" & os = "linux" ]
+available: [ ocaml-version >= "4.01.0" ]

--- a/solo5-bindings/Makefile
+++ b/solo5-bindings/Makefile
@@ -1,7 +1,7 @@
 OPAM_DIR=$(shell opam config var prefix)
 
 FREESTANDING_CFLAGS=$(shell PKG_CONFIG_PATH=$(OPAM_DIR)/lib/pkgconfig pkg-config ocaml-freestanding --cflags)
-CC=gcc
+CC?=cc
 CFLAGS=-O2 -g -Wall -Werror $(FREESTANDING_CFLAGS)
 
 OBJS=\


### PR DESCRIPTION
`CC?=cc` (history repeating), and adjust opam to allow building on non-linux systems (I expect this to work as well on OpenBSD/NetBSD/MacOSX)